### PR TITLE
Update cluster-network-11-ncp-cluster-role.yaml

### DIFF
--- a/openshift4/cluster-network-11-ncp-cluster-role.yaml
+++ b/openshift4/cluster-network-11-ncp-cluster-role.yaml
@@ -6,3 +6,6 @@ rules:
   resources: [deployments, endpoints, pods/log, nodes, replicationcontrollers, secrets,
     routes, network, networks]
   verbs: [get, watch, list]
+- apiGroups: [route.openshift.io]
+  resources: [routes]
+  verbs: [get, watch, list]


### PR DESCRIPTION
In NCP Pod, seeing error such as the below, fixed by altering the RBAC to add in api route.openshift.io against resource: routes


NSX 11 - [nsx@6876 comp="nsx-container-ncp" subcomp="ncp" level="INFO"] nsx_ujo.common.utils Failed to execute function watcher_handler: Failed routes request: Failed to get routes : None, error:                 {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"routes.route.openshift.io is forbidden: User \"system:serviceaccount:nsx-system:ncp-svc-account\" cannot list resource \"routes\" in API group \"route.openshift.io\" at the cluster scope","reason":"Forbidden","details":{"group":"route.openshift.io","kind":"routes"},"code":403}
 ., will retry after 5 seconds